### PR TITLE
Limit the creation of duplicated issues

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,9 +79,17 @@ fi
 cd ..
 rm -rf work
 
-echo "merge_result=${MERGE_RESULT}" >> $GITHUB_OUTPUT
-echo "conflicts=${CONFLICTS}" >> $GITHUB_OUTPUT
-echo "completed=${PERCENTAGE_DIFF_FILES}" >> $GITHUB_OUTPUT
+echo "merge_result<<EOF" >> $GITHUB_OUTPUT
+echo "${MERGE_RESULT}" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+
+echo "conflicts<<EOF" >> $GITHUB_OUTPUT
+echo "${CONFLICTS}" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+
+echo "completed<<EOF" >> $GITHUB_OUTPUT
+echo "${PERCENTAGE_DIFF_FILES}" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
 
 if [[ $CONFLICTS ]]
 then 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,26 +90,20 @@ then
   echo  >> bodyfile 
   echo "Complete message: " >> bodyfile 
   echo "${MERGE_RESULT}" >> bodyfile
-  GH_TOKEN=${GITHUB_TOKEN} 
-  gh issue create --repo https://github.com/${GITHUB_REPOSITORY}.git --title "$UPSTREAM_BRANCH Fix merging conflict" --body-file bodyfile --label "automatic-sync-merge" 
-  
-  EMPTY_RESPONSE="no issues match your search in $GITHUB_REPOSITORY"
-  echo "$EMPTY_RESPONSE"
 
   touch placeholder.txt
 
   GH_TOKEN=${GITHUB_TOKEN} gh issue list --label automatic-sync-merge --repo https://github.com/${GITHUB_REPOSITORY}.git >> placeholder.txt
-  cat placeholder.txt
-  echo "flag"
-  AUTOMATIC_ISSUE_LIST=cat placeholder.txt
-  echo "$AUTOMATIC_ISSUE_LIST"
 
-  if [ "$AUTOMATIC_ISSUE_LIST" = "$EMPTY_RESPONSE"]
+  AUTOMATIC_ISSUE_LIST=`cat placeholder.txt`
+  #echo "$AUTOMATIC_ISSUE_LIST"
+
+  #avoid created duplicated issue
+  #create the issue if the previous automatic-sync is no longer open
+  if [[ $AUTOMATIC_ISSUE_LIST = "" ]]
   then 
-    echo " condition success"
-    # gh auth login --git-protocol https --hostname GitHub.com --with-token < gt
-  else
-    echo " condition not met"
+    GH_TOKEN=${GITHUB_TOKEN} gh issue create --repo https://github.com/${GITHUB_REPOSITORY}.git --title "$UPSTREAM_BRANCH Fix merging conflict" --body-file bodyfile --label "automatic-sync-merge" 
+  
      
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,17 +90,26 @@ then
   echo  >> bodyfile 
   echo "Complete message: " >> bodyfile 
   echo "${MERGE_RESULT}" >> bodyfile
- 
-  GH_TOKEN=${GITHUB_TOKEN} gh issue create --repo https://github.com/${GITHUB_REPOSITORY}.git --title "$UPSTREAM_BRANCH Fix merging conflict" --body-file bodyfile --label "automatic-sync-merge" 
+  GH_TOKEN=${GITHUB_TOKEN} 
+  gh issue create --repo https://github.com/${GITHUB_REPOSITORY}.git --title "$UPSTREAM_BRANCH Fix merging conflict" --body-file bodyfile --label "automatic-sync-merge" 
   
   EMPTY_RESPONSE="no issues match your search in $GITHUB_REPOSITORY"
   echo "$EMPTY_RESPONSE"
-  AUTOMATIC_ISSUE_LIST=$(GH_TOKEN=${GITHUB_TOKEN} gh issue list --label automatic-sync-merge --repo https://github.com/${GITHUB_REPOSITORY}.git)
+
+  touch placeholder.txt
+
+  GH_TOKEN=${GITHUB_TOKEN} gh issue list --label automatic-sync-merge --repo https://github.com/${GITHUB_REPOSITORY}.git >> placeholder.txt
+  cat placeholder.txt
+  echo "flag"
+  AUTOMATIC_ISSUE_LIST=cat placeholder.txt
   echo "$AUTOMATIC_ISSUE_LIST"
 
-  #if ["$AUTOMATIC_ISSUE_LIST" ="$EMPTY_RESPONSE"]
-  #then 
+  if [ "$AUTOMATIC_ISSUE_LIST" = "$EMPTY_RESPONSE"]
+  then 
+    echo " condition success"
     # gh auth login --git-protocol https --hostname GitHub.com --with-token < gt
-   
-  #fi
+  else
+    echo " condition not met"
+     
+  fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,10 +90,17 @@ then
   echo  >> bodyfile 
   echo "Complete message: " >> bodyfile 
   echo "${MERGE_RESULT}" >> bodyfile
+ 
+  GH_TOKEN=${GITHUB_TOKEN} gh issue create --repo https://github.com/${GITHUB_REPOSITORY}.git --title "$UPSTREAM_BRANCH Fix merging conflict" --body-file bodyfile --label "automatic-sync-merge" 
+  
+  EMPTY_RESPONSE="no issues match your search in $GITHUB_REPOSITORY"
+  echo "$EMPTY_RESPONSE"
+  AUTOMATIC_ISSUE_LIST=$(GH_TOKEN=${GITHUB_TOKEN} gh issue list --label automatic-sync-merge --repo https://github.com/${GITHUB_REPOSITORY}.git)
+  echo "$AUTOMATIC_ISSUE_LIST"
 
-  # if GH_TOKEN=${GITHUB_TOKEN} gh issue list --repo https://github.com/${GITHUB_REPOSITORY}.git | grep -v "Fix conflict in $CONFLICTS"
-  # then 
+  #if ["$AUTOMATIC_ISSUE_LIST" ="$EMPTY_RESPONSE"]
+  #then 
     # gh auth login --git-protocol https --hostname GitHub.com --with-token < gt
-    GH_TOKEN=${GITHUB_TOKEN} gh issue create --repo https://github.com/${GITHUB_REPOSITORY}.git --title "Fix conflict in $CONFLICTS" --body-file bodyfile
-  # fi
+   
+  #fi
 fi


### PR DESCRIPTION
relates to #3 
This feature creates a condition to avoid the creation of repeated issues:

-  uses gh cli to search for issues with the tag `automatic-sync`
-   stores the ouput in a placeholder.txt file
-  read the file and if it is empty, it creates a new issue
- the issue created was reformatted to include the  tag `automatic-sync` 
- changes into the title were also introduce to:
   -  identify the branch the action was perform at
   - and remove the list of files with conflicts from the title, as they made it too long when there were many conflicts 
- also fixes #1 by implementing #2  

For the action to work the `automatic-sync` tag must exist in the repo. So it should be manually created before using the action for the first time.
